### PR TITLE
test(tools): add deterministic subsystem test suites for wikipedia, arxiv, and calculator tools

### DIFF
--- a/tests/helpers/source_test_map.py
+++ b/tests/helpers/source_test_map.py
@@ -88,6 +88,20 @@ SOURCE_TEST_RULES: tuple[SourceTestRule, ...] = (
         "Gmail changes need deterministic input-schema and provider-conversion contracts.",
     ),
     SourceTestRule(
+        "tools_utility_and_retrieval",
+        (
+            "src/row_bot/tools/wikipedia_tool.py",
+            "src/row_bot/tools/arxiv_tool.py",
+            "src/row_bot/tools/calculator_tool.py",
+        ),
+        (
+            "tests/subsystem/tools/test_wikipedia_tool_subsystem.py",
+            "tests/subsystem/tools/test_arxiv_tool_subsystem.py",
+            "tests/subsystem/tools/test_calculator_tool_subsystem.py",
+        ),
+        "Wikipedia, ArXiv, and Calculator tool changes need deterministic subsystem test contracts.",
+    ),
+    SourceTestRule(
         "startup_runtime",
         (
             "src/row_bot/app_port.py",

--- a/tests/subsystem/tools/test_arxiv_tool_subsystem.py
+++ b/tests/subsystem/tools/test_arxiv_tool_subsystem.py
@@ -1,0 +1,311 @@
+"""Deterministic subsystem tests for the ArXiv tool.
+
+Tests cover:
+- Tool identity and registration contracts
+- Result formatting (title, authors, date, abstract, links)
+- Empty result handling
+- Error propagation from the arxiv client
+- Author truncation (>5 authors)
+- Version suffix stripping from HTML URLs
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = pytest.mark.subsystem
+
+
+# ── Fake arxiv objects ───────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeAuthor:
+    """Minimal stand-in for arxiv.Result.Author."""
+
+    name: str
+
+
+@dataclass
+class _FakeResult:
+    """Minimal stand-in for arxiv.Result."""
+
+    title: str
+    summary: str
+    published: datetime
+    primary_category: str
+    pdf_url: str
+    entry_id: str
+    authors: list[_FakeAuthor] = field(default_factory=list)
+    _short_id: str = ""
+
+    def get_short_id(self) -> str:
+        return self._short_id
+
+
+class _FakeClient:
+    """Mimics arxiv.Client.results() returning pre-built results."""
+
+    def __init__(self, results: list[_FakeResult]) -> None:
+        self._results = results
+
+    def results(self, search) -> list[_FakeResult]:
+        return self._results
+
+
+class _ErrorClient:
+    """Raises an exception when results() is called."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def results(self, search):
+        raise self._exc
+
+
+# ── Identity & registration ─────────────────────────────────────────────────
+
+
+def test_arxiv_tool_name_and_display_name(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    tool = ArxivTool()
+    assert tool.name == "arxiv"
+    assert tool.display_name == "📚 Arxiv"
+
+
+def test_arxiv_tool_enabled_by_default(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    assert ArxivTool().enabled_by_default is True
+
+
+def test_arxiv_tool_requires_no_api_keys(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    assert ArxivTool().required_api_keys == {}
+
+
+def test_arxiv_tool_is_registered(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools import registry
+
+    import row_bot.tools.arxiv_tool  # noqa: F401
+
+    tool = registry.get_tool("arxiv")
+    assert tool is not None
+    assert tool.name == "arxiv"
+
+
+# ── Successful retrieval ─────────────────────────────────────────────────────
+
+
+def _make_fake_result(
+    title: str = "Attention Is All You Need",
+    summary: str = "We propose a new architecture called the Transformer.",
+    authors: list[str] | None = None,
+    published: datetime | None = None,
+    short_id: str = "1706.03762v7",
+    category: str = "cs.CL",
+) -> _FakeResult:
+    if authors is None:
+        authors = ["Ashish Vaswani", "Noam Shazeer", "Niki Parmar"]
+    if published is None:
+        published = datetime(2017, 6, 12)
+    return _FakeResult(
+        title=title,
+        summary=summary,
+        published=published,
+        primary_category=category,
+        pdf_url=f"https://arxiv.org/pdf/{short_id}",
+        entry_id=f"http://arxiv.org/abs/{short_id}",
+        authors=[_FakeAuthor(name=a) for a in authors],
+        _short_id=short_id,
+    )
+
+
+def test_execute_formats_single_result_correctly(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    fake_result = _make_fake_result()
+    tool = ArxivTool()
+
+    with patch("arxiv.Client", return_value=_FakeClient([fake_result])), \
+         patch("arxiv.Search"):
+        result = tool.execute("transformer architecture")
+
+    assert "[1] Attention Is All You Need" in result
+    assert "Authors: Ashish Vaswani, Noam Shazeer, Niki Parmar" in result
+    assert "Published: 2017-06-12" in result
+    assert "Categories: cs.CL" in result
+    assert "We propose a new architecture" in result
+    assert "https://arxiv.org/html/1706.03762" in result
+    assert "SOURCE_URL:" in result
+    assert "Tip: To read a paper's full text" in result
+
+
+def test_execute_formats_multiple_results(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    results = [
+        _make_fake_result(title="Paper A", short_id="2301.00001v1"),
+        _make_fake_result(title="Paper B", short_id="2301.00002v2"),
+        _make_fake_result(title="Paper C", short_id="2301.00003v1"),
+    ]
+    tool = ArxivTool()
+
+    with patch("arxiv.Client", return_value=_FakeClient(results)), \
+         patch("arxiv.Search"):
+        result = tool.execute("deep learning")
+
+    assert "[1] Paper A" in result
+    assert "[2] Paper B" in result
+    assert "[3] Paper C" in result
+    # Results separated by ---
+    assert "---" in result
+
+
+# ── HTML URL version stripping ───────────────────────────────────────────────
+
+
+def test_version_suffix_stripped_from_html_url(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    fake = _make_fake_result(short_id="2401.12345v3")
+    tool = ArxivTool()
+
+    with patch("arxiv.Client", return_value=_FakeClient([fake])), \
+         patch("arxiv.Search"):
+        result = tool.execute("test")
+
+    # The HTML URL should NOT have the version suffix
+    assert "https://arxiv.org/html/2401.12345" in result
+    # It should NOT contain v3 in the HTML URL
+    assert "https://arxiv.org/html/2401.12345v3" not in result
+
+
+def test_no_version_suffix_handled_gracefully(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    fake = _make_fake_result(short_id="2401.12345")
+    tool = ArxivTool()
+
+    with patch("arxiv.Client", return_value=_FakeClient([fake])), \
+         patch("arxiv.Search"):
+        result = tool.execute("test")
+
+    assert "https://arxiv.org/html/2401.12345" in result
+
+
+# ── Author truncation ────────────────────────────────────────────────────────
+
+
+def test_more_than_five_authors_shows_et_al(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    many_authors = [f"Author {i}" for i in range(1, 9)]  # 8 authors
+    fake = _make_fake_result(authors=many_authors)
+    tool = ArxivTool()
+
+    with patch("arxiv.Client", return_value=_FakeClient([fake])), \
+         patch("arxiv.Search"):
+        result = tool.execute("test")
+
+    # First 5 authors listed
+    assert "Author 1" in result
+    assert "Author 5" in result
+    # 6th author not listed directly
+    assert "Author 6" not in result.split("et al.")[0]
+    # et al. with count
+    assert "et al." in result
+    assert "8 authors" in result
+
+
+def test_five_or_fewer_authors_no_truncation(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    three_authors = ["Alice", "Bob", "Charlie"]
+    fake = _make_fake_result(authors=three_authors)
+    tool = ArxivTool()
+
+    with patch("arxiv.Client", return_value=_FakeClient([fake])), \
+         patch("arxiv.Search"):
+        result = tool.execute("test")
+
+    assert "Alice, Bob, Charlie" in result
+    assert "et al." not in result
+
+
+# ── Empty results & errors ───────────────────────────────────────────────────
+
+
+def test_execute_returns_message_on_empty_results(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    tool = ArxivTool()
+
+    with patch("arxiv.Client", return_value=_FakeClient([])), \
+         patch("arxiv.Search"):
+        result = tool.execute("xyznonexistenttopic12345")
+
+    assert "No arXiv papers found" in result
+
+
+def test_execute_returns_error_on_client_failure(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    tool = ArxivTool()
+
+    with patch("arxiv.Client", return_value=_ErrorClient(ConnectionError("timeout"))), \
+         patch("arxiv.Search"):
+        result = tool.execute("test query")
+
+    assert "arXiv search error" in result
+    assert "timeout" in result
+
+
+# ── Description contract ─────────────────────────────────────────────────────
+
+
+def test_description_mentions_query_syntax(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    desc = ArxivTool().description
+    assert "ti:" in desc
+    assert "au:" in desc
+    assert "cat:" in desc
+
+
+# ── LangChain tool wrapper ──────────────────────────────────────────────────
+
+
+def test_as_langchain_tool_returns_structured_tool(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.arxiv_tool import ArxivTool
+
+    tool = ArxivTool()
+    lc_tools = tool.as_langchain_tools()
+
+    assert len(lc_tools) == 1
+    assert lc_tools[0].name == "arxiv"
+    assert len(lc_tools[0].description) > 0

--- a/tests/subsystem/tools/test_calculator_tool_subsystem.py
+++ b/tests/subsystem/tools/test_calculator_tool_subsystem.py
@@ -1,0 +1,429 @@
+"""Deterministic subsystem tests for the Calculator tool.
+
+Tests cover:
+- Tool identity and registration contracts
+- Basic arithmetic operations
+- Mathematical functions (sqrt, sin, cos, log, factorial, etc.)
+- Constants (pi, e, tau)
+- Integer result formatting (no trailing .0)
+- Division by zero handling
+- Invalid expression handling
+- Math domain errors (e.g. sqrt of negative)
+- Overflow protection
+- Safety — no access to builtins like import, exec, eval, os
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+
+pytestmark = pytest.mark.subsystem
+
+
+# ── Identity & registration ─────────────────────────────────────────────────
+
+
+def test_calculator_tool_name_and_display_name(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import CalculatorTool
+
+    tool = CalculatorTool()
+    assert tool.name == "calculator"
+    assert tool.display_name == "🧮 Calculator"
+
+
+def test_calculator_tool_enabled_by_default(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import CalculatorTool
+
+    assert CalculatorTool().enabled_by_default is True
+
+
+def test_calculator_tool_requires_no_api_keys(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import CalculatorTool
+
+    assert CalculatorTool().required_api_keys == {}
+
+
+def test_calculator_tool_is_registered(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools import registry
+
+    import row_bot.tools.calculator_tool  # noqa: F401
+
+    tool = registry.get_tool("calculator")
+    assert tool is not None
+    assert tool.name == "calculator"
+
+
+# ── Basic arithmetic ────────────────────────────────────────────────────────
+
+
+def test_addition(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("2 + 3")
+    assert "= 5" in result
+
+
+def test_subtraction(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("10 - 4")
+    assert "= 6" in result
+
+
+def test_multiplication(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("7 * 8")
+    assert "= 56" in result
+
+
+def test_division(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("15 / 3")
+    assert "= 5" in result
+
+
+def test_floor_division(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("17 // 3")
+    assert "= 5" in result
+
+
+def test_modulo(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("17 % 5")
+    assert "= 2" in result
+
+
+def test_exponentiation(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("2 ** 10")
+    assert "= 1024" in result
+
+
+# ── Mathematical functions ───────────────────────────────────────────────────
+
+
+def test_sqrt(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("sqrt(144)")
+    assert "= 12" in result
+
+
+def test_abs_function(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("abs(-42)")
+    assert "= 42" in result
+
+
+def test_round_function(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("round(3.7)")
+    assert "= 4" in result
+
+
+def test_factorial(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("factorial(10)")
+    assert "= 3628800" in result
+
+
+def test_log_natural(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("log(e)")
+    assert "= 1" in result
+
+
+def test_log2(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("log2(1024)")
+    assert "= 10" in result
+
+
+def test_log10(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("log10(1000)")
+    assert "= 3" in result
+
+
+def test_sin_of_zero(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("sin(0)")
+    assert "= 0" in result
+
+
+def test_cos_of_zero(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("cos(0)")
+    assert "= 1" in result
+
+
+def test_ceil_function(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("ceil(4.2)")
+    assert "= 5" in result
+
+
+def test_floor_function(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("floor(4.8)")
+    assert "= 4" in result
+
+
+def test_gcd(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("gcd(48, 18)")
+    assert "= 6" in result
+
+
+def test_pow_function(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("pow(3, 4)")
+    assert "= 81" in result
+
+
+def test_min_max(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    assert "= 1" in _calculate("min(1, 5, 3)")
+    assert "= 5" in _calculate("max(1, 5, 3)")
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+
+def test_pi_constant(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("pi")
+    assert str(math.pi) in result
+
+
+def test_e_constant(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("e")
+    assert str(math.e) in result
+
+
+def test_tau_constant(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("tau")
+    assert str(math.tau) in result
+
+
+# ── Integer formatting ───────────────────────────────────────────────────────
+
+
+def test_integer_result_has_no_trailing_dot_zero(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("10.0 + 5.0")
+    # Should show = 15, not = 15.0
+    assert "= 15" in result
+    assert ".0" not in result.split("=")[1]
+
+
+def test_float_result_preserved_when_not_integer(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("10 / 3")
+    assert "3.333" in result
+
+
+# ── Error handling ───────────────────────────────────────────────────────────
+
+
+def test_division_by_zero(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("1 / 0")
+    assert "division by zero" in result.lower()
+
+
+def test_invalid_expression(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("2 + * 3")
+    # Should return an error, not crash
+    assert "error" in result.lower() or "invalid" in result.lower()
+
+
+def test_sqrt_of_negative_returns_math_error(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("sqrt(-1)")
+    assert "error" in result.lower() or "math" in result.lower()
+
+
+def test_empty_expression(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("")
+    # Should handle gracefully, not crash
+    assert isinstance(result, str)
+
+
+# ── Safety: blocked dangerous operations ─────────────────────────────────────
+
+
+def test_import_blocked(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("__import__('os').system('echo hacked')")
+    # simpleeval should reject this
+    assert "error" in result.lower() or "invalid" in result.lower()
+
+
+def test_exec_blocked(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("exec('print(1)')")
+    assert "error" in result.lower() or "invalid" in result.lower()
+
+
+def test_eval_blocked(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("eval('2+2')")
+    assert "error" in result.lower() or "invalid" in result.lower()
+
+
+def test_open_blocked(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("open('/etc/passwd')")
+    assert "error" in result.lower() or "invalid" in result.lower()
+
+
+def test_attribute_access_blocked(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("''.__class__.__mro__")
+    assert "error" in result.lower() or "invalid" in result.lower()
+
+
+# ── execute() method ─────────────────────────────────────────────────────────
+
+
+def test_execute_delegates_to_calculate(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import CalculatorTool
+
+    tool = CalculatorTool()
+    result = tool.execute("2 ** 8")
+    assert "= 256" in result
+
+
+# ── LangChain tool wrapper ──────────────────────────────────────────────────
+
+
+def test_as_langchain_tools_returns_calculate_tool(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import CalculatorTool
+
+    tool = CalculatorTool()
+    lc_tools = tool.as_langchain_tools()
+
+    assert len(lc_tools) == 1
+    assert lc_tools[0].name == "calculate"
+    assert "sqrt" in lc_tools[0].description
+    assert "factorial" in lc_tools[0].description
+
+
+def test_langchain_tool_accepts_expression_argument(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import CalculatorTool
+
+    tool = CalculatorTool()
+    lc_tool = tool.as_langchain_tools()[0]
+
+    # The StructuredTool should accept an `expression` argument
+    result = lc_tool.invoke({"expression": "sqrt(25)"})
+    assert "= 5" in result
+
+
+# ── Combined expression tests ────────────────────────────────────────────────
+
+
+def test_nested_function_calls(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    result = _calculate("round(sqrt(2), 4)")
+    assert "1.4142" in result
+
+
+def test_expression_with_constants_and_functions(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.calculator_tool import _calculate
+
+    # 2 * pi should be approximately tau
+    result = _calculate("round(2 * pi, 10)")
+    assert str(round(2 * math.pi, 10)) in result

--- a/tests/subsystem/tools/test_wikipedia_tool_subsystem.py
+++ b/tests/subsystem/tools/test_wikipedia_tool_subsystem.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/subsystem/tools/test_wikipedia_tool_subsystem.py
+++ b/tests/subsystem/tools/test_wikipedia_tool_subsystem.py
@@ -1,0 +1,275 @@
+"""Deterministic subsystem tests for the Wikipedia tool.
+
+Tests cover:
+- Tool identity and registration contracts
+- HTTPS API URL enforcement
+- Graceful error handling on retriever failures
+- Output format with sources
+- Empty result handling
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+
+
+pytestmark = pytest.mark.subsystem
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeDocument:
+    """Minimal stand-in for langchain_core.documents.Document."""
+
+    page_content: str
+    metadata: dict
+
+
+class _FakeRetriever:
+    """Returns canned documents for any query."""
+
+    def __init__(self, docs: list[_FakeDocument]) -> None:
+        self._docs = docs
+
+    def invoke(self, query: str) -> list[_FakeDocument]:
+        return self._docs
+
+
+class _EmptyRetriever(_FakeRetriever):
+    """Always returns no results."""
+
+    def __init__(self) -> None:
+        super().__init__([])
+
+
+class _ErrorRetriever:
+    """Raises a configurable exception on every invoke."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def invoke(self, query: str):
+        raise self._exc
+
+
+# ── Identity & registration ─────────────────────────────────────────────────
+
+
+def test_wikipedia_tool_name_and_display_name(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    tool = WikipediaTool()
+    assert tool.name == "wikipedia"
+    assert tool.display_name == "🌐 Wikipedia"
+
+
+def test_wikipedia_tool_enabled_by_default(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    assert WikipediaTool().enabled_by_default is True
+
+
+def test_wikipedia_tool_requires_no_api_keys(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    assert WikipediaTool().required_api_keys == {}
+
+
+def test_wikipedia_tool_is_registered(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools import registry
+
+    # Import the module to trigger registration
+    import row_bot.tools.wikipedia_tool  # noqa: F401
+
+    tool = registry.get_tool("wikipedia")
+    assert tool is not None
+    assert tool.name == "wikipedia"
+
+
+# ── HTTPS enforcement ────────────────────────────────────────────────────────
+
+
+def test_configure_wikipedia_client_upgrades_http_to_https(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    import wikipedia.wikipedia as wiki_impl
+    from row_bot.tools.wikipedia_tool import _configure_wikipedia_client
+
+    original = wiki_impl.API_URL
+    try:
+        wiki_impl.API_URL = "http://en.wikipedia.org/w/api.php"
+        _configure_wikipedia_client()
+        assert wiki_impl.API_URL == "https://en.wikipedia.org/w/api.php"
+    finally:
+        wiki_impl.API_URL = original
+
+
+def test_configure_wikipedia_client_leaves_https_unchanged(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    import wikipedia.wikipedia as wiki_impl
+    from row_bot.tools.wikipedia_tool import _configure_wikipedia_client
+
+    original = wiki_impl.API_URL
+    try:
+        wiki_impl.API_URL = "https://en.wikipedia.org/w/api.php"
+        _configure_wikipedia_client()
+        assert wiki_impl.API_URL == "https://en.wikipedia.org/w/api.php"
+    finally:
+        wiki_impl.API_URL = original
+
+
+# ── Error handling ───────────────────────────────────────────────────────────
+
+
+def test_execute_returns_recovery_message_on_json_error(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    tool = WikipediaTool()
+    monkeypatch.setattr(
+        tool,
+        "get_retriever",
+        lambda **kwargs: _ErrorRetriever(
+            json.JSONDecodeError("Expecting value", "", 0)
+        ),
+    )
+
+    result = tool.execute("nonexistent topic")
+
+    assert "temporarily unavailable" in result
+    assert "Do not retry the Wikipedia tool" in result
+    assert "answer from general knowledge" in result
+
+
+def test_execute_returns_recovery_message_on_connection_error(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    tool = WikipediaTool()
+    monkeypatch.setattr(
+        tool,
+        "get_retriever",
+        lambda **kwargs: _ErrorRetriever(ConnectionError("network unreachable")),
+    )
+
+    result = tool.execute("test query")
+
+    assert "temporarily unavailable" in result
+    assert "ConnectionError" in result
+
+
+def test_execute_returns_recovery_on_generic_exception(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    tool = WikipediaTool()
+    monkeypatch.setattr(
+        tool,
+        "get_retriever",
+        lambda **kwargs: _ErrorRetriever(RuntimeError("unexpected")),
+    )
+
+    result = tool.execute("test query")
+
+    assert "temporarily unavailable" in result
+    assert "RuntimeError" in result
+
+
+# ── Successful retrieval ─────────────────────────────────────────────────────
+
+
+def test_execute_formats_results_with_sources(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    tool = WikipediaTool()
+    docs = [
+        _FakeDocument(
+            page_content="Python is a programming language.",
+            metadata={"source": "https://en.wikipedia.org/wiki/Python"},
+        ),
+        _FakeDocument(
+            page_content="Guido van Rossum created Python.",
+            metadata={"source": "https://en.wikipedia.org/wiki/Guido_van_Rossum"},
+        ),
+    ]
+    monkeypatch.setattr(
+        tool, "get_retriever", lambda **kwargs: _FakeRetriever(docs)
+    )
+
+    result = tool.execute("Python programming")
+
+    assert "[Result 1]" in result
+    assert "[Result 2]" in result
+    assert "Python is a programming language." in result
+    assert "Guido van Rossum created Python." in result
+    assert "SOURCE_URL: https://en.wikipedia.org/wiki/Python" in result
+    assert "SOURCE_URL: https://en.wikipedia.org/wiki/Guido_van_Rossum" in result
+
+
+def test_execute_returns_no_results_message_on_empty(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    tool = WikipediaTool()
+    monkeypatch.setattr(
+        tool, "get_retriever", lambda **kwargs: _EmptyRetriever()
+    )
+
+    result = tool.execute("xyznonexistenttopic12345")
+
+    assert "No results found" in result
+
+
+# ── Description contract ─────────────────────────────────────────────────────
+
+
+def test_description_guides_agent_on_broad_vs_specific_queries(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    desc = WikipediaTool().description.lower()
+
+    assert "encyclopedia" in desc or "encyclopedic" in desc
+    assert "broad" in desc
+    assert "sources" in desc or "source" in desc
+
+
+# ── LangChain tool wrapper ──────────────────────────────────────────────────
+
+
+def test_as_langchain_tool_returns_structured_tool(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("ROW_BOT_DATA_DIR", str(tmp_path / ".row-bot"))
+    from row_bot.tools.wikipedia_tool import WikipediaTool
+
+    tool = WikipediaTool()
+    lc_tools = tool.as_langchain_tools()
+
+    assert len(lc_tools) == 1
+    assert lc_tools[0].name == "wikipedia"
+    assert len(lc_tools[0].description) > 0


### PR DESCRIPTION
## Summary

Adds deterministic subsystem test suites for three core tools that previously lacked subsystem test coverage: `wikipedia_tool`, `arxiv_tool`, and `calculator_tool`.

### Changes Included
- **Wikipedia Tool** (`tests/subsystem/tools/test_wikipedia_tool_subsystem.py`):
  - Identity (`wikipedia`), default enablement, and zero API key requirement contracts.
  - Automatic HTTP -> HTTPS API endpoint upgrade enforcement.
  - Defensive recovery behavior when upstream API returns JSON parse errors or network exceptions.
  - Document formatting and source metadata attribution (`SOURCE_URL`).
- **ArXiv Tool** (`tests/subsystem/tools/test_arxiv_tool_subsystem.py`):
  - Search result formatting (Title, Authors, Published Date, Category, Abstract, HTML/PDF links).
  - Version suffix stripping for HTML links (`https://arxiv.org/html/...`).
  - Author truncation (`et al.` formatting when > 5 authors).
  - Empty search result and client failure handling.
- **Calculator Tool** (`tests/subsystem/tools/test_calculator_tool_subsystem.py`):
  - Arithmetic operators, math functions (`sqrt`, `log`, `sin`, `factorial`, `gcd`, etc.), and constants (`pi`, `e`, `tau`).
  - Whole integer result formatting (no trailing `.0`).
  - Division by zero and invalid expression error boundaries.
  - **Security validation**: Verified that dangerous Python execution/imports (`__import__`, `exec`, `eval`, `open`, attribute access) are strictly blocked.
- **Source Test Map** (`tests/helpers/source_test_map.py`):
  - Added `tools_utility_and_retrieval` rule so modifying any of the three tool source files automatically triggers these tests during CI test matrix runs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [x] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [x] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [ ] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
