### PR TITLE
fix: harden OpenAI-compatible request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,10 @@ cached, and fallback catalog outcomes.
 
 Configure providers in Settings, Channels, and Accounts. Keys and in-app ChatGPT / Codex, Claude Subscription, and xAI Grok OAuth tokens are stored in Windows Credential Manager, macOS Keychain, or Linux Secret Service/KWallet when available. If secure storage is unavailable, newly entered secrets are usable for the current Row-Bot process only and must be re-entered after restart unless a secure keyring backend is configured. The official Compose path automatically creates a persistent `ROW_BOT_SECRET_STORE_KEY` in its isolated secrets volume and uses it to encrypt owner-entered credentials under `/data/secure-secrets`; advanced operators can replace that volume with an explicit read-only secret file. Back up the key and data together; see [Docker And VPS Operations](https://row-bot.ai/docs/operations/docker#account-credential-persistence-is-automatic). `~/.row-bot/api_keys.json` and `~/.row-bot/providers.json` keep metadata only, such as saved state, provider status, Quick Choices, compatibility profiles, runtime and vision probe results, OAuth client-id diagnostics, model-count status, and masked fingerprints.
 
+OpenAI-compatible chat requests use a 900-second read-inactivity timeout. Set
+`ROW_BOT_OPENAI_COMPATIBLE_READ_TIMEOUT` to a positive number of seconds to
+override it for all OpenAI-compatible endpoints.
+
 Atlas Cloud uses an OpenAI-compatible API, but Row-Bot treats it as a
 first-class provider with its own setup, auth, catalog refresh, provider
 identity, capability labels, streaming behavior, and chat/agent/vision surface

--- a/src/row_bot/providers/transports/openai_compatible.py
+++ b/src/row_bot/providers/transports/openai_compatible.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import math
+import os
 import re
 from contextlib import nullcontext
 from typing import Any, Iterator, Sequence
@@ -16,6 +18,31 @@ from row_bot.cancellation import current_cancellation_scope
 
 logger = logging.getLogger(__name__)
 
+OPENAI_COMPATIBLE_READ_TIMEOUT_ENV = "ROW_BOT_OPENAI_COMPATIBLE_READ_TIMEOUT"
+DEFAULT_OPENAI_COMPATIBLE_READ_TIMEOUT = 900.0
+OPENAI_COMPATIBLE_CONNECT_TIMEOUT = 10.0
+OPENAI_COMPATIBLE_WRITE_TIMEOUT = 120.0
+OPENAI_COMPATIBLE_POOL_TIMEOUT = 10.0
+OPENAI_COMPATIBLE_STREAM_ATTEMPTS = 2
+
+
+def _default_read_timeout() -> float:
+    raw = str(os.environ.get(OPENAI_COMPATIBLE_READ_TIMEOUT_ENV) or "").strip()
+    if not raw:
+        return DEFAULT_OPENAI_COMPATIBLE_READ_TIMEOUT
+    try:
+        timeout = float(raw)
+    except ValueError:
+        timeout = 0.0
+    if math.isfinite(timeout) and timeout > 0:
+        return timeout
+    logger.warning(
+        "Ignoring invalid %s; using %.0f seconds",
+        OPENAI_COMPATIBLE_READ_TIMEOUT_ENV,
+        DEFAULT_OPENAI_COMPATIBLE_READ_TIMEOUT,
+    )
+    return DEFAULT_OPENAI_COMPATIBLE_READ_TIMEOUT
+
 
 class ChatOpenAICompatible(BaseChatModel):
     """OpenAI-compatible chat transport with endpoint-specific normalization."""
@@ -24,7 +51,7 @@ class ChatOpenAICompatible(BaseChatModel):
     api_key: str = "not-needed"
     base_url: str
     endpoint: dict[str, Any] = Field(default_factory=dict)
-    timeout: float = 120.0
+    timeout: float = Field(default_factory=_default_read_timeout)
     http_client: Any | None = None
 
     @property
@@ -350,12 +377,13 @@ class ChatOpenAICompatible(BaseChatModel):
     def _post(self, body: dict[str, Any]) -> Any:
         client = self.http_client or _new_http_client(self.timeout)
         owns_client = self.http_client is None
+        request_timeout = _httpx_timeout(self.timeout)
         try:
             response = client.post(
                 _chat_url(self.base_url),
                 json=body,
                 headers=self._headers(),
-                timeout=self.timeout,
+                timeout=request_timeout,
             )
             _raise_for_status(response, self.endpoint)
             return response
@@ -364,8 +392,37 @@ class ChatOpenAICompatible(BaseChatModel):
                 client.close()
 
     def _iter_stream_events(self, body: dict[str, Any]) -> Iterator[dict[str, Any]]:
+        import httpx
+
+        scope = current_cancellation_scope()
+        for attempt in range(1, OPENAI_COMPATIBLE_STREAM_ATTEMPTS + 1):
+            if scope is not None and scope.is_cancelled():
+                return
+            produced = 0
+            try:
+                for payload in self._iter_stream_events_once(body):
+                    produced += 1
+                    yield payload
+                return
+            except (httpx.TimeoutException, httpx.RemoteProtocolError) as exc:
+                if scope is not None and scope.is_cancelled():
+                    return
+                if produced or attempt >= OPENAI_COMPATIBLE_STREAM_ATTEMPTS:
+                    raise
+                logger.warning(
+                    "custom_openai_stream: transport failed before first event; retrying "
+                    "provider=%s model=%s attempt=%d/%d error=%s",
+                    self.endpoint.get("provider_id") or "custom",
+                    self.model_name,
+                    attempt + 1,
+                    OPENAI_COMPATIBLE_STREAM_ATTEMPTS,
+                    type(exc).__name__,
+                )
+
+    def _iter_stream_events_once(self, body: dict[str, Any]) -> Iterator[dict[str, Any]]:
         client = self.http_client or _new_http_client(self.timeout)
         owns_client = self.http_client is None
+        request_timeout = _httpx_timeout(self.timeout)
         scope = current_cancellation_scope()
         unregister_callbacks: list[Any] = []
         raw_lines = 0
@@ -378,12 +435,12 @@ class ChatOpenAICompatible(BaseChatModel):
                 _chat_url(self.base_url),
                 json=body,
                 headers=self._headers(),
-                timeout=self.timeout,
+                timeout=request_timeout,
             ) if hasattr(client, "stream") else nullcontext(client.post(
                 _chat_url(self.base_url),
                 json=body,
                 headers=self._headers(),
-                timeout=self.timeout,
+                timeout=request_timeout,
             ))
             with context as response:
                 _raise_for_status(response, self.endpoint)
@@ -1087,7 +1144,18 @@ def _text_tool_call_from_match(match: re.Match[str], index: int) -> dict[str, An
 def _new_http_client(timeout: float) -> Any:
     import httpx
 
-    return httpx.Client(timeout=timeout)
+    return httpx.Client(timeout=_httpx_timeout(timeout))
+
+
+def _httpx_timeout(read_timeout: float) -> Any:
+    import httpx
+
+    return httpx.Timeout(
+        connect=OPENAI_COMPATIBLE_CONNECT_TIMEOUT,
+        read=float(read_timeout),
+        write=OPENAI_COMPATIBLE_WRITE_TIMEOUT,
+        pool=OPENAI_COMPATIBLE_POOL_TIMEOUT,
+    )
 
 
 def _chat_url(base_url: str) -> str:

--- a/tests/test_openai_compatible_transport.py
+++ b/tests/test_openai_compatible_transport.py
@@ -1,6 +1,7 @@
 import json
 import threading
 
+import httpx
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
@@ -49,6 +50,39 @@ class _StreamResponse:
 class _StreamingClient(_Client):
     def stream(self, method, url, **kwargs):
         self.calls.append((url, kwargs))
+        return _StreamResponse()
+
+
+class _FailingStreamResponse:
+    status_code = 200
+    text = ""
+
+    def __init__(self, exc: Exception, *lines: bytes):
+        self.exc = exc
+        self.lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def iter_lines(self):
+        yield from self.lines
+        raise self.exc
+
+
+class _RetryingStreamingClient(_Client):
+    def __init__(self, exc: Exception, *first_lines: bytes, always_fail: bool = False):
+        super().__init__()
+        self.exc = exc
+        self.first_lines = first_lines
+        self.always_fail = always_fail
+
+    def stream(self, method, url, **kwargs):
+        self.calls.append((url, kwargs))
+        if len(self.calls) == 1 or self.always_fail:
+            return _FailingStreamResponse(self.exc, *self.first_lines)
         return _StreamResponse()
 
 
@@ -377,6 +411,40 @@ class _ReasoningResponse(_Response):
                 },
             }],
         })
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        (None, 900.0),
+        ("720", 720.0),
+        ("not-a-timeout", 900.0),
+    ],
+)
+def test_openai_compatible_transport_uses_granular_configurable_read_timeout(
+    monkeypatch,
+    configured,
+    expected,
+):
+    if configured is None:
+        monkeypatch.delenv("ROW_BOT_OPENAI_COMPATIBLE_READ_TIMEOUT", raising=False)
+    else:
+        monkeypatch.setenv("ROW_BOT_OPENAI_COMPATIBLE_READ_TIMEOUT", configured)
+    client = _Client()
+    model = ChatOpenAICompatible(
+        model_name="qwen",
+        base_url="http://127.0.0.1:8000/v1",
+        http_client=client,
+    )
+
+    model.invoke([HumanMessage(content="hi")])
+
+    timeout = client.calls[0][1]["timeout"]
+    assert model.timeout == expected
+    assert timeout.connect == 10.0
+    assert timeout.read == expected
+    assert timeout.write == 120.0
+    assert timeout.pool == 10.0
 
 
 def test_openai_compatible_transport_moves_system_messages_first():
@@ -710,6 +778,63 @@ def test_openai_compatible_transport_streams_reasoning_chunks():
 
     assert chunks[0].additional_kwargs["reasoning_content"] == "thinking"
     assert chunks[1].content == "answer"
+
+
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        httpx.ReadTimeout("read timed out"),
+        httpx.RemoteProtocolError("peer closed the stream"),
+    ],
+)
+def test_openai_compatible_stream_retries_transport_failure_before_first_event(transport_error):
+    client = _RetryingStreamingClient(transport_error)
+    model = ChatOpenAICompatible(
+        model_name="qwen",
+        base_url="http://127.0.0.1:1234/v1",
+        endpoint={"provider_id": "custom_openai_lm-studio"},
+        http_client=client,
+    )
+
+    events = list(model._iter_stream_events({"stream": True, "messages": []}))
+
+    assert len(client.calls) == 2
+    assert [event["choices"][0]["delta"] for event in events] == [
+        {"reasoning_content": "thinking"},
+        {"content": "answer"},
+    ]
+
+
+def test_openai_compatible_stream_does_not_retry_after_first_event():
+    first_event = b'data: {"choices":[{"delta":{"content":"partial"}}]}'
+    client = _RetryingStreamingClient(httpx.ReadTimeout("read timed out"), first_event)
+    model = ChatOpenAICompatible(
+        model_name="qwen",
+        base_url="http://127.0.0.1:1234/v1",
+        endpoint={"provider_id": "custom_openai_lm-studio"},
+        http_client=client,
+    )
+    events = model._iter_stream_events({"stream": True, "messages": []})
+
+    assert next(events)["choices"][0]["delta"] == {"content": "partial"}
+    with pytest.raises(httpx.ReadTimeout):
+        next(events)
+    assert len(client.calls) == 1
+
+
+def test_openai_compatible_stream_retry_is_bounded_to_two_attempts():
+    client = _RetryingStreamingClient(httpx.ReadTimeout("read timed out"), always_fail=True)
+    model = ChatOpenAICompatible(
+        model_name="qwen",
+        base_url="http://127.0.0.1:1234/v1",
+        endpoint={"provider_id": "custom_openai_lm-studio"},
+        http_client=client,
+    )
+
+    with pytest.raises(httpx.ReadTimeout):
+        list(model._iter_stream_events({"stream": True, "messages": []}))
+
+    assert len(client.calls) == 2
 
 
 def test_atlascloud_streams_visible_content_after_tool_result_with_tools_bound():

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -148,6 +148,7 @@ def test_custom_openai_endpoint_uses_configured_base_url(tmp_path, monkeypatch):
     from row_bot.providers.custom import custom_provider_id, save_custom_endpoint
 
     monkeypatch.setattr(provider_config, "CONFIG_PATH", tmp_path / "providers.json")
+    monkeypatch.setenv("ROW_BOT_OPENAI_COMPATIBLE_READ_TIMEOUT", "720")
 
     save_custom_endpoint({
         "id": "local-vllm",
@@ -163,6 +164,7 @@ def test_custom_openai_endpoint_uses_configured_base_url(tmp_path, monkeypatch):
     assert model.base_url == "http://127.0.0.1:8000/v1"
     assert model.api_key == "not-needed"
     assert model.endpoint["provider_id"] == custom_provider_id("local-vllm")
+    assert model.timeout == 720.0
 
 
 def test_custom_endpoint_model_syncs_into_model_facade(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [x] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [x] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [ ] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [x] Windows/macOS behavior considered where relevant
