### PR TITLE
Harden Telegram startup resilience

### DIFF
--- a/src/row_bot/app.py
+++ b/src/row_bot/app.py
@@ -977,11 +977,12 @@ async def _run_startup_sequence():
         _main_app_tunnel = _main_app_tunnel[0] is True
         _ch_config.set("tunnel", "tunnel_main_app", _main_app_tunnel)
     if _main_app_tunnel is True:
+        _set("🌐 Starting remote access tunnel…")
         try:
             from row_bot.tunnel import tunnel_manager
             with _startup_phase("main_app_tunnel_autostart"):
                 if tunnel_manager.is_available():
-                    tunnel_manager.start_tunnel(_APP_PORT, label="main_app")
+                    await asyncio.to_thread(tunnel_manager.start_tunnel, _APP_PORT, label="main_app")
                     _safe_console_print(f"[startup] ✅ Main-app tunnel auto-started on port {_APP_PORT}")
                 else:
                     _status_code, status_detail = tunnel_manager.status()
@@ -1522,9 +1523,7 @@ async def index():
           const poll = async () => {
             try {
               const response = await fetch('/readyz', {cache: 'no-store'});
-              if (!response.ok) return;
-              const state = await response.json();
-              if (state && state.ready) {
+              if (response.ok) {
                 window.location.reload();
               }
             } catch (_) {}

--- a/src/row_bot/channels/telegram.py
+++ b/src/row_bot/channels/telegram.py
@@ -29,6 +29,7 @@ import time
 from typing import Any
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, BotCommand, ReactionTypeEmoji
+from telegram.error import InvalidToken, NetworkError
 from telegram.ext import (
     Application,
     CommandHandler,
@@ -101,6 +102,7 @@ _pending_task_approvals: dict[int, dict] = {}  # {message_id: {resume_token, tas
 _pending_skill_choices: dict[str, dict] = {}  # {token: {thread_id, action, choices}}
 _pending_lock = threading.Lock()  # Guards both _pending_interrupts and _pending_task_approvals
 _PENDING_TTL_SECONDS = 3600  # 1 hour — entries older than this are cleaned up
+_INITIALIZE_RETRY_DELAY_SECONDS = 1
 
 
 def _cleanup_stale_pending() -> None:
@@ -2084,6 +2086,36 @@ async def _handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 # ──────────────────────────────────────────────────────────────────────
 # Lifecycle: start / stop the polling bot
 # ──────────────────────────────────────────────────────────────────────
+async def _cleanup_failed_start(application: Application) -> None:
+    """Best-effort cleanup for a partially started Telegram application."""
+    updater = application.updater
+    cleanup_steps = (
+        ("updater stop", updater.stop if updater and updater.running else None),
+        ("application stop", application.stop if application.running else None),
+        ("application shutdown", application.shutdown),
+        ("bot shutdown", application.bot.shutdown),
+    )
+    for step, operation in cleanup_steps:
+        if operation is None:
+            continue
+        try:
+            await operation()
+        except Exception as exc:
+            log.warning(
+                "Telegram startup cleanup failed during %s (%s)",
+                step,
+                type(exc).__name__,
+            )
+
+
+async def _register_bot_commands(application: Application) -> None:
+    """Register Telegram commands without affecting the live polling bot."""
+    try:
+        await application.bot.set_my_commands(BOT_COMMANDS)
+    except Exception as exc:
+        log.warning("Could not register bot commands (%s)", type(exc).__name__)
+
+
 async def start_bot() -> bool:
     """Initialise and start the Telegram bot (long polling).
 
@@ -2127,19 +2159,46 @@ async def start_bot() -> bool:
     _app.add_handler(MessageHandler(filters.Document.ALL, _handle_document))
     _app.add_handler(CallbackQueryHandler(_handle_callback))
 
-    # Register commands with BotFather for autocomplete
-    try:
-        await _app.bot.set_my_commands(BOT_COMMANDS)
-    except Exception as exc:
-        log.warning("Could not register bot commands: %s", exc)
-
     # Initialise and start polling
-    await _app.initialize()
-    await _app.start()
-    await _app.updater.start_polling(drop_pending_updates=True)
+    try:
+        for attempt in range(2):
+            try:
+                await _app.initialize()
+                break
+            except NetworkError as exc:
+                if attempt == 1:
+                    raise
+                log.warning(
+                    "Telegram initialization failed (%s); retrying once in one second",
+                    type(exc).__name__,
+                )
+                await asyncio.sleep(_INITIALIZE_RETRY_DELAY_SECONDS)
+        await _app.start()
+        await _app.updater.start_polling(
+            drop_pending_updates=True,
+            bootstrap_retries=1,
+        )
+    except InvalidToken:
+        await _cleanup_failed_start(_app)
+        _app = None
+        _running = False
+        _bot_loop = None
+        raise RuntimeError(
+            "Telegram rejected the configured bot token; update it in Settings."
+        ) from None
+    except Exception:
+        await _cleanup_failed_start(_app)
+        _app = None
+        _running = False
+        _bot_loop = None
+        raise
 
     _bot_loop = asyncio.get_running_loop()
     _running = True
+    asyncio.create_task(
+        _register_bot_commands(_app),
+        name="telegram-register-commands",
+    )
 
     # Periodic cleanup of stale pending dicts (every 10 minutes)
     async def _periodic_cleanup():

--- a/src/row_bot/ui/settings.py
+++ b/src/row_bot/ui/settings.py
@@ -5877,7 +5877,7 @@ def open_settings(
                     else:
                         ui.notify(f"⚠️ Could not start {ch.display_name}", type="warning")
                 except Exception as exc:
-                    ui.notify(f"Error starting {ch.display_name}: {exc}", type="negative")
+                    _report_manual_channel_start_failure(ch, exc)
                 _update_channel_status(status_container, ch)
                 _refresh_header()
                 # Keep expansion open so QR code / status is visible
@@ -6522,3 +6522,13 @@ def open_settings(
         initial_tab=_initial_name,
     )
     defer_ui(lambda: _schedule_settings_tab(_initial_name), delay=0.05)
+
+
+def _report_manual_channel_start_failure(channel: Any, exc: Exception) -> None:
+    """Log a credential-safe diagnostic and preserve the existing notification."""
+    logger.warning(
+        "Manual channel start failed: channel=%s error_type=%s",
+        channel.name,
+        type(exc).__name__,
+    )
+    ui.notify(f"Error starting {channel.display_name}: {exc}", type="negative")

--- a/tests/subsystem/channels/test_telegram_lifecycle.py
+++ b/tests/subsystem/channels/test_telegram_lifecycle.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+from telegram.error import InvalidToken, TimedOut
+
+from row_bot.channels import telegram
+
+
+FAKE_TOKEN = "123456:FAKE_SECRET_TOKEN"
+
+
+class FakeBot:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        command_error: Exception | None = None,
+    ) -> None:
+        self.events = events
+        self.command_error = command_error
+        self.command_calls = 0
+        self.shutdown_calls = 0
+
+    async def set_my_commands(self, commands: Any) -> None:
+        self.command_calls += 1
+        self.events.append("commands")
+        if self.command_error is not None:
+            raise self.command_error
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self.events.append("bot_shutdown")
+
+
+class FakeUpdater:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.running = False
+        self.polling_calls: list[dict[str, Any]] = []
+        self.stop_calls = 0
+
+    async def start_polling(self, **kwargs: Any) -> None:
+        self.polling_calls.append(kwargs)
+        self.events.append("polling")
+        self.running = True
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        self.running = False
+        self.events.append("updater_stop")
+
+
+class FakeApplication:
+    def __init__(
+        self,
+        initialize_outcomes: list[Exception | None],
+        *,
+        command_error: Exception | None = None,
+    ) -> None:
+        self.events: list[str] = []
+        self.initialize_outcomes = list(initialize_outcomes)
+        self.initialize_calls = 0
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.shutdown_calls = 0
+        self.running = False
+        self.bot = FakeBot(self.events, command_error=command_error)
+        self.updater = FakeUpdater(self.events)
+        self.handlers: list[Any] = []
+
+    def add_handler(self, handler: Any) -> None:
+        self.handlers.append(handler)
+
+    async def initialize(self) -> None:
+        self.initialize_calls += 1
+        self.events.append("initialize")
+        outcome = self.initialize_outcomes.pop(0)
+        if outcome is not None:
+            raise outcome
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        self.running = True
+        self.events.append("start")
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        self.running = False
+        self.events.append("app_stop")
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self.events.append("app_shutdown")
+
+
+class FakeApplicationBuilder:
+    def __init__(self, applications: list[FakeApplication]) -> None:
+        self.applications = applications
+
+    def token(self, token: str) -> FakeApplicationBuilder:
+        assert token == FAKE_TOKEN
+        return self
+
+    def build(self) -> FakeApplication:
+        return self.applications.pop(0)
+
+
+@pytest.fixture(autouse=True)
+def reset_telegram_lifecycle():
+    telegram._app = None
+    telegram._running = False
+    telegram._bot_loop = None
+    yield
+    telegram._app = None
+    telegram._running = False
+    telegram._bot_loop = None
+
+
+def configure_applications(
+    monkeypatch: pytest.MonkeyPatch,
+    applications: list[FakeApplication],
+) -> None:
+    builder = FakeApplicationBuilder(applications)
+
+    class FakeApplicationAPI:
+        @staticmethod
+        def builder() -> FakeApplicationBuilder:
+            return builder
+
+    monkeypatch.setattr(telegram, "Application", FakeApplicationAPI)
+    monkeypatch.setattr(telegram, "is_configured", lambda: True)
+    monkeypatch.setattr(telegram, "_get_bot_token", lambda: FAKE_TOKEN)
+    monkeypatch.setattr(telegram, "_INITIALIZE_RETRY_DELAY_SECONDS", 0)
+
+
+def test_initialize_network_error_retries_once_and_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    application = FakeApplication([TimedOut("temporary failure"), None])
+    configure_applications(monkeypatch, [application])
+
+    result = asyncio.run(telegram.start_bot())
+
+    assert result is True
+    assert application.initialize_calls == 2
+    assert application.updater.polling_calls == [
+        {"drop_pending_updates": True, "bootstrap_retries": 1}
+    ]
+    assert telegram._app is application
+    assert telegram._running is True
+    assert telegram._bot_loop is not None
+
+
+def test_initialize_network_error_twice_cleans_partial_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_error = TimedOut("persistent temporary failure")
+    application = FakeApplication([original_error, original_error])
+    configure_applications(monkeypatch, [application])
+
+    with pytest.raises(TimedOut) as exc_info:
+        asyncio.run(telegram.start_bot())
+
+    assert exc_info.value is original_error
+    assert application.initialize_calls == 2
+    assert application.shutdown_calls == 1
+    assert application.bot.shutdown_calls == 1
+    assert telegram._app is None
+    assert telegram._running is False
+    assert telegram._bot_loop is None
+
+
+def test_invalid_token_is_not_retried_and_surfaces_safe_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    application = FakeApplication(
+        [InvalidToken(f"The token `{FAKE_TOKEN}` was rejected by the server.")]
+    )
+    configure_applications(monkeypatch, [application])
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(telegram.start_bot())
+
+    assert application.initialize_calls == 1
+    assert FAKE_TOKEN not in str(exc_info.value)
+    assert application.shutdown_calls == 1
+    assert application.bot.shutdown_calls == 1
+    assert telegram._app is None
+    assert telegram._running is False
+    assert telegram._bot_loop is None
+
+
+def test_command_registration_failure_does_not_stop_polling(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    application = FakeApplication(
+        [None],
+        command_error=TimedOut("command registration timed out"),
+    )
+    configure_applications(monkeypatch, [application])
+
+    async def run_case() -> bool:
+        result = await telegram.start_bot()
+        await asyncio.sleep(0)
+        return result
+
+    with caplog.at_level(logging.WARNING, logger="row_bot.telegram"):
+        result = asyncio.run(run_case())
+
+    assert result is True
+    assert application.events.index("polling") < application.events.index("commands")
+    assert application.bot.command_calls == 1
+    assert telegram._app is application
+    assert telegram._running is True
+    assert "Could not register bot commands (TimedOut)" in caplog.text
+
+
+def test_fresh_application_can_start_after_failed_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_error = TimedOut("startup still unavailable")
+    failed_application = FakeApplication([original_error, original_error])
+    succeeding_application = FakeApplication([None])
+    configure_applications(
+        monkeypatch,
+        [failed_application, succeeding_application],
+    )
+
+    async def run_case() -> bool:
+        with pytest.raises(TimedOut):
+            await telegram.start_bot()
+        assert telegram._app is None
+        return await telegram.start_bot()
+
+    result = asyncio.run(run_case())
+
+    assert result is True
+    assert failed_application.bot.shutdown_calls == 1
+    assert succeeding_application.initialize_calls == 1
+    assert telegram._app is succeeding_application
+    assert telegram._running is True

--- a/tests/test_startup_hardening.py
+++ b/tests/test_startup_hardening.py
@@ -193,6 +193,43 @@ def test_startup_speed_imports_are_lazy_source_contract():
     assert "def create_react_agent" in agent_src
 
 
+def test_startup_splash_uses_readyz_http_status_source_contract():
+    app_src = Path("src/row_bot/app.py").read_text(encoding="utf-8")
+
+    assert "fetch('/readyz', {cache: 'no-store'})" in app_src
+    assert "if (response.ok)" in app_src
+    assert "state.ready" not in app_src
+    assert "await response.json()" not in app_src
+
+
+def test_main_app_tunnel_startup_is_offloaded_source_contract():
+    app_src = Path("src/row_bot/app.py").read_text(encoding="utf-8")
+
+    status = '_set("🌐 Starting remote access tunnel…")'
+    offloaded_start = (
+        'await asyncio.to_thread(tunnel_manager.start_tunnel, _APP_PORT, label="main_app")'
+    )
+    assert status in app_src
+    assert offloaded_start in app_src
+    assert app_src.index(status) < app_src.index(offloaded_start)
+
+
+def test_manual_channel_start_logs_safe_diagnostic_source_contract():
+    settings_src = Path("src/row_bot/ui/settings.py").read_text(encoding="utf-8")
+    start_handler = settings_src.split("async def _start_ch", 1)[1].split(
+        "async def _stop_ch", 1
+    )[0]
+    diagnostic = settings_src.split(
+        "def _report_manual_channel_start_failure", 1
+    )[1]
+
+    assert "_report_manual_channel_start_failure(ch, exc)" in start_handler
+    assert "Manual channel start failed: channel=%s error_type=%s" in diagnostic
+    assert "channel.name," in diagnostic
+    assert "type(exc).__name__," in diagnostic
+    assert "logger.exception" not in diagnostic
+
+
 def test_channel_adapters_do_not_import_agent_at_module_import_time():
     for path in [
         Path("src/row_bot/channels/telegram.py"),


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [x] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [ ] Other

## Testing

- [x] I ran `uv run python scripts/run_test_matrix.py fast`
- [x] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [x] I added or updated tests
- [x] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [x] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [ ] Branch is based on latest `main`
- [ ] No direct secrets, API keys, local paths, or private data included
- [ ] The change is focused and does not include unrelated cleanup
- [ ] Windows/macOS behavior considered where relevant
