### PR TITLE
fix: correct macOS Cua probe paths

### DIFF
--- a/.github/workflows/macos-cua-probe.yml
+++ b/.github/workflows/macos-cua-probe.yml
@@ -28,9 +28,6 @@ jobs:
   probe:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
-    env:
-      PROBE_ROOT: ${{ runner.temp }}/row-bot-cua-probe
-      PROBE_REPORT: ${{ runner.temp }}/row-bot-cua-probe/report.json
 
     steps:
       - name: Require explicit Cua telemetry notice acceptance
@@ -58,14 +55,14 @@ jobs:
         run: |
           uv run python scripts/probe_macos_cua.py \
             --accept-cua-notice \
-            --data-dir "$PROBE_ROOT/data" \
-            --output "$PROBE_REPORT"
+            --data-dir "$RUNNER_TEMP/row-bot-cua-probe/data" \
+            --output "macos-cua-probe-report/report.json"
 
       - name: Upload sanitized probe report
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: macos-cua-probe-${{ inputs.runner }}
-          path: ${{ env.PROBE_REPORT }}
+          path: macos-cua-probe-report/report.json
           if-no-files-found: warn
           retention-days: 14

--- a/tests/subsystem/computer_use/test_macos_cua_probe.py
+++ b/tests/subsystem/computer_use/test_macos_cua_probe.py
@@ -63,6 +63,16 @@ def test_probe_workflow_is_manual_opt_in_and_separate_from_ci() -> None:
     assert workflow["permissions"] == {"contents": "read"}
     job = workflow["jobs"]["probe"]
     assert job["runs-on"] == "${{ inputs.runner }}"
-    assert any(
-        "scripts/probe_macos_cua.py" in step.get("run", "") for step in job["steps"]
+    assert "env" not in job
+    probe = next(
+        step
+        for step in job["steps"]
+        if "scripts/probe_macos_cua.py" in step.get("run", "")
     )
+    assert "$RUNNER_TEMP/row-bot-cua-probe/data" in probe["run"]
+    upload = next(
+        step
+        for step in job["steps"]
+        if step.get("uses") == "actions/upload-artifact@v7"
+    )
+    assert upload["with"]["path"] == "macos-cua-probe-report/report.json"


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [x] Test-only change
- [ ] Build / CI / release tooling

## Risk area

- [ ] Agent / prompts / tools
- [ ] Designer
- [ ] Memory / knowledge graph
- [ ] Channels / external integrations
- [ ] Installers / auto-update
- [ ] UI only
- [x] Other

## Testing

- [ ] I ran `uv run python scripts/run_test_matrix.py fast`
- [ ] I ran `uv run python scripts/run_test_matrix.py pr` for shared, release-sensitive, or cross-subsystem changes
- [ ] I added or updated tests
- [ ] I updated the relevant inventory in `tests/helpers/` when changing coverage ownership
- [ ] I manually tested the affected user flow
- [ ] Not applicable, docs-only change

## Release notes

- [ ] User-visible change, release notes needed
- [x] Internal-only change, no release note needed

## Checklist

- [x] Branch is based on latest `main`
- [x] No direct secrets, API keys, local paths, or private data included
- [x] The change is focused and does not include unrelated cleanup
- [ ] Windows/macOS behavior considered where relevant
